### PR TITLE
Lazy LED Orochi Chroma fix

### DIFF
--- a/KeyboardVisualizerCommon/RazerChroma.cpp
+++ b/KeyboardVisualizerCommon/RazerChroma.cpp
@@ -297,6 +297,7 @@ bool RazerChroma::SetLEDs(COLORREF pixels[64][256])
             }
         }
 
+        CreateEffect(ChromaSDK::OROCHI_CHROMA, ChromaSDK::CHROMA_NONE, NULL, NULL); // Quick-fix for "lazy" Orochi Chroma color transition effect, see https://gfycat.com/DiscreteDisfiguredBluetickcoonhound
         CreateMouseEffect(ChromaSDK::Mouse::CHROMA_CUSTOM2, &MouseEffect, NULL);
 
         //Kraken Chroma

--- a/README.md
+++ b/README.md
@@ -146,13 +146,16 @@ Keyboard Visualizer allows you to save your custom settings in two different way
         Mice
         - Diamondback Chroma (bar and single color)
         - Mamba Tournament Edition (bar and single color)
+        - Mamba Chroma Wireless (bar and single color, wired and wireless)
         - DeathAdder Chroma (single color)
         - Naga Epic Chroma (single color, wired only)
         - Naga Chroma (single color)
+        - Orochi Chroma (single color, wired only)
         
         Headsets
         - Kraken 7.1 Chroma (single color)
         - Kraken 7.1 Chroma V2 (single color)
+        - ManO'War (single color)
         
         Mouse Mats
         - Firefly (bar)
@@ -198,7 +201,7 @@ Keyboard Visualizer allows you to save your custom settings in two different way
 
 # Supported Devices (Linux)
 
-    * Razer Drivers (https://github.com/terrycain/razer-drivers)
+    * Razer Linux Drivers (https://github.com/terrycain/razer-drivers)
 
         Keyboards
         - BlackWidow Chroma (spectrograph)


### PR DESCRIPTION
A fix for the Orochi Chroma to work properly. Currently it only "fades" very slowly between effects. This fix makes the effect reset, similar to how Kraken works. See https://gfycat.com/DiscreteDisfiguredBluetickcoonhound

I can implement checking if Orochi is connected but that would require adding QueryDevice DLL definitions