### PR TITLE
Update RazerChromaLinux.cpp

### DIFF
--- a/KeyboardVisualizerCommon/RazerChromaLinux.cpp
+++ b/KeyboardVisualizerCommon/RazerChromaLinux.cpp
@@ -31,8 +31,12 @@ int BlackWidowXIndex[22];
 int BlackWidowYIndex[6];
 
 //Index lists for Blade
-int BladeXIndex[25];
+int BladeXIndex[16];
 int BladeYIndex[6];
+
+//Index lists for Blade Pro 2016
+int BladeProXIndex[25];
+int BladeProYIndex[6];
 
 //Index list for Firefly
 int FireflyIndex[15];
@@ -393,7 +397,10 @@ void RazerChroma::Initialize()
     SetupKeyboardGrid(22, 6, BlackWidowXIndex, BlackWidowYIndex);
 
     //Build index list for Blade
-    SetupKeyboardGrid(25, 6, BladeXIndex, BladeYIndex);
+    SetupKeyboardGrid(16, 6, BladeXIndex, BladeYIndex);
+
+    //Build index list for Blade Pro 2016
+    SetupKeyboardGrid(25, 6, BladeProXIndex, BladeProYIndex);
 
     //Build index list for Firefly
     for (int x = 0; x < 15; x++)
@@ -489,9 +496,9 @@ bool RazerChroma::SetLEDs(COLORREF pixels[64][256])
 
                         for(int x = 0; x < 25; x++)
                         {
-                            BladeEffect[3 + (x * 3)] = GetRValue(pixels[BladeYIndex[y]][BladeXIndex[x]]);
-                            BladeEffect[4 + (x * 3)] = GetGValue(pixels[BladeYIndex[y]][BladeXIndex[x]]);
-                            BladeEffect[5 + (x * 3)] = GetBValue(pixels[BladeYIndex[y]][BladeXIndex[x]]);
+                            BladeEffect[3 + (x * 3)] = GetRValue(pixels[BladeProYIndex[y]][BladeProXIndex[x]]);
+                            BladeEffect[4 + (x * 3)] = GetGValue(pixels[BladeProYIndex[y]][BladeProXIndex[x]]);
+                            BladeEffect[5 + (x * 3)] = GetBValue(pixels[BladeProYIndex[y]][BladeProXIndex[x]]);
                         }
 
                         write(razer_fd_1[i], &BladeEffect, sizeof(BladeEffect));

--- a/KeyboardVisualizerCommon/RazerChromaLinux.cpp
+++ b/KeyboardVisualizerCommon/RazerChromaLinux.cpp
@@ -14,8 +14,10 @@ enum
     RAZER_DEATHSTALKER_CHROMA,
     RAZER_ORNATA_CHROMA,
     RAZER_BLADE_STEALTH,
+    RAZER_BLADE_PRO,
     RAZER_TARTARUS_CHROMA,
     RAZER_DEATHADDER_CHROMA,
+    RAZER_DEATHADDER_ELITE,
     RAZER_NAGA_CHROMA,
     RAZER_DIAMONDBACK_CHROMA,
     RAZER_MAMBA_TOURNAMENT_EDITION_CHROMA,
@@ -29,7 +31,7 @@ int BlackWidowXIndex[22];
 int BlackWidowYIndex[6];
 
 //Index lists for Blade
-int BladeXIndex[16];
+int BladeXIndex[25];
 int BladeYIndex[6];
 
 //Index list for Firefly
@@ -168,6 +170,13 @@ void RazerChroma::Initialize()
 
                             device_type = RAZER_BLADE_STEALTH;
                         }
+                        else if(!strncmp(device_string, "Razer Blade Pro (Late 2016)", strlen("Razer Blade Pro (Late 2016)")))
+                        {
+                            //Device is Razer Blade Pro 2016
+                            printf("Blade Pro 2016 Detected\r\n");
+
+                            device_type = RAZER_BLADE_PRO;
+                        }
                         else if(!strncmp(device_string, "Razer Tartarus Chroma", strlen("Razer Tartarus Chroma")))
                         {
                             //Device is Razer Tartarus Chroma
@@ -181,6 +190,13 @@ void RazerChroma::Initialize()
                             printf("DeathAdder Chroma Detected\r\n");
 
                             device_type = RAZER_DEATHADDER_CHROMA;
+                        }
+                        else if(!strncmp(device_string, "Razer DeathAdder Elite", strlen("Razer DeathAdder Elite")))
+                        {
+                            //Device is Razer DeathAdder Elite
+                            printf("DeathAdder Elite Detected\r\n");
+
+                            device_type = RAZER_DEATHADDER_ELITE;
                         }
                         else if(!strncmp(device_string, "Razer Naga Chroma", strlen("Razer Naga Chroma")))
                         {
@@ -264,6 +280,7 @@ void RazerChroma::Initialize()
                                     case RAZER_DEATHSTALKER_CHROMA:
                                     case RAZER_ORNATA_CHROMA:
                                     case RAZER_BLADE_STEALTH:
+                                    case RAZER_BLADE_PRO:
                                     case RAZER_FIREFLY_CHROMA:
                                     case RAZER_MUG_HOLDER:
                                     case RAZER_MAMBA_TOURNAMENT_EDITION_CHROMA:
@@ -325,6 +342,7 @@ void RazerChroma::Initialize()
                                     //Devices with logo LED rgb and effect parameters
                                     case RAZER_DEATHADDER_CHROMA:
                                     case RAZER_NAGA_CHROMA:
+                                    case RAZER_DEATHADDER_ELITE:
                                         {
                                             //Device is unique, go ahead and register it
                                             strcpy(device_string, driver_path);
@@ -375,7 +393,7 @@ void RazerChroma::Initialize()
     SetupKeyboardGrid(22, 6, BlackWidowXIndex, BlackWidowYIndex);
 
     //Build index list for Blade
-    SetupKeyboardGrid(16, 6, BladeXIndex, BladeYIndex);
+    SetupKeyboardGrid(25, 6, BladeXIndex, BladeYIndex);
 
     //Build index list for Firefly
     for (int x = 0; x < 15; x++)
@@ -446,6 +464,30 @@ bool RazerChroma::SetLEDs(COLORREF pixels[64][256])
                         BladeEffect[0] = y;
 
                         for(int x = 0; x < 16; x++)
+                        {
+                            BladeEffect[3 + (x * 3)] = GetRValue(pixels[BladeYIndex[y]][BladeXIndex[x]]);
+                            BladeEffect[4 + (x * 3)] = GetGValue(pixels[BladeYIndex[y]][BladeXIndex[x]]);
+                            BladeEffect[5 + (x * 3)] = GetBValue(pixels[BladeYIndex[y]][BladeXIndex[x]]);
+                        }
+
+                        write(razer_fd_1[i], &BladeEffect, sizeof(BladeEffect));
+                    }
+                    write(razer_fd_2[i], &BladeEffect, 1);
+                }
+                break;
+
+            case RAZER_BLADE_PRO:
+                {
+                    char BladeEffect[((3 * 25)) + 3];
+
+                    BladeEffect[1] = 0;
+                    BladeEffect[2] = 24;
+
+                    for(int y = 0; y < 6; y++)
+                    {
+                        BladeEffect[0] = y;
+
+                        for(int x = 0; x < 25; x++)
                         {
                             BladeEffect[3 + (x * 3)] = GetRValue(pixels[BladeYIndex[y]][BladeXIndex[x]]);
                             BladeEffect[4 + (x * 3)] = GetGValue(pixels[BladeYIndex[y]][BladeXIndex[x]]);
@@ -601,6 +643,7 @@ bool RazerChroma::SetLEDs(COLORREF pixels[64][256])
 
             case RAZER_DEATHADDER_CHROMA:
             case RAZER_NAGA_CHROMA:
+            case RAZER_DEATHADDER_ELITE:
                 {
                     char DeathAdderEffect[3];
 


### PR DESCRIPTION
Added support for Razer Blade Pro and Death Adder Elite.  Death Adder Elite does not work.  It has two LEDs (logo and scrollwheel) just like your Death Adder Chroma and Naga Chroma.  However examining around line 346 where the devices listed: logo_led_rgb, logo_led_effect, scroll_led_rgb, scroll_led_effect are different from my local setup which looks as follows:
rsandoz-Blade-Pro:/sys/bus/hid/drivers/razermouse/0003:1532:005C.0001# ls  -la
total 0
drwxr-xr-x 5 root plugdev    0 Jan  8 16:48 .
drwxr-xr-x 5 root root       0 Jan  8 17:05 ..
-r--r--r-- 1 root plugdev 4096 Jan  8 16:48 country
-rw-rw---- 1 root plugdev 4096 Jan  8 16:48 device_mode
-r--r----- 1 root plugdev 4096 Jan  8 16:48 device_serial
-r--r----- 1 root plugdev 4096 Jan  8 16:48 device_type
-rw-rw---- 1 root plugdev 4096 Jan  8 16:48 dpi
lrwxrwxrwx 1 root plugdev    0 Jan  8 16:48 driver -> ../../../../../../../bus/hid/drivers/razermouse
-r--r----- 1 root plugdev 4096 Jan  8 16:48 firmware_version
drwxr-xr-x 3 root plugdev    0 Jan  8 16:48 hidraw
drwxr-xr-x 3 root plugdev    0 Jan  8 16:48 input
-rw-rw---- 1 root plugdev 4096 Jan  8 16:48 logo_led_brightness
--w--w---- 1 root plugdev 4096 Jan  8 16:48 logo_matrix_effect_breath
--w--w---- 1 root plugdev 4096 Jan  8 16:55 logo_matrix_effect_none
--w--w---- 1 root plugdev 4096 Jan  8 16:48 logo_matrix_effect_reactive
--w--w---- 1 root plugdev 4096 Jan  8 16:48 logo_matrix_effect_spectrum
--w--w---- 1 root plugdev 4096 Jan  8 16:56 logo_matrix_effect_static
-r--r--r-- 1 root plugdev 4096 Jan  8 16:48 modalias
-rw-rw---- 1 root plugdev 4096 Jan  8 16:48 poll_rate
drwxr-xr-x 2 root plugdev    0 Jan  8 16:48 power
-r--r--r-- 1 root plugdev 4096 Jan  8 16:48 report_descriptor
-rw-rw---- 1 root plugdev 4096 Jan  8 16:48 scroll_led_brightness
--w--w---- 1 root plugdev 4096 Jan  8 16:48 scroll_matrix_effect_breath
--w--w---- 1 root plugdev 4096 Jan  8 16:55 scroll_matrix_effect_none
--w--w---- 1 root plugdev 4096 Jan  8 16:48 scroll_matrix_effect_reactive
--w--w---- 1 root plugdev 4096 Jan  8 16:48 scroll_matrix_effect_spectrum
--w--w---- 1 root plugdev 4096 Jan  8 16:48 scroll_matrix_effect_static
lrwxrwxrwx 1 root plugdev    0 Jan  8 16:48 subsystem -> ../../../../../../../bus/hid
--w--w---- 1 root plugdev 4096 Jan  8 16:48 test
-rw-r--r-- 1 root plugdev 4096 Jan  8 16:48 uevent
-r--r----- 1 root plugdev 4096 Jan  8 16:48 version
