### PR TITLE
Led Fading Out on Application Close

### DIFF
--- a/KeyboardVisualizerCommon/Visualizer.cpp
+++ b/KeyboardVisualizerCommon/Visualizer.cpp
@@ -468,6 +468,7 @@ void Visualizer::ChangeAudioDevice()
 
 void Visualizer::Initialize()
 {
+	appRunning = true;
     InitAudioDeviceList();
 
     //Initialize devices supported only under Windows
@@ -989,14 +990,32 @@ void Visualizer::StartThread()
 
 void Visualizer::DrawRGBOut()
 {
-	COLORREF color = 0x00000000;
-	for (int x = 0; x < 256; x++)
-	{
-		for (int y = 0; y < 64; y++)
+	appRunning = false;
+	Sleep(20);
+	pixels_out = &pixels_fg;
+	int color;
+	bool black = false;
+	while (black == false) {
+		
+		for (int x = 0; x < 256; x++)
 		{
-			pixels_render->pixels[y][x] = RGB((GetRValue(color) / 256), (GetGValue(color) / 256), (GetBValue(color) / 256));
+			for (int y = 0; y < 64; y++)
+			{
+				color = pixels_out->pixels[y][x];
+				if (color == 0)
+				{
+					black = true;
+				}
+				else
+				{
+					pixels_out->pixels[y][x] = RGB((GetRValue(color) )*0.8, (GetGValue(color) )*0.8, (GetBValue(color) )*0.8);
+					
+				}
+			}
 		}
+		Sleep(delay*2);
 	}
+	Sleep(delay * 2);
 }
 
 void DrawSolidColor(int bright, COLORREF color, vis_pixels *pixels)
@@ -1413,7 +1432,7 @@ void Visualizer::NetUpdateThread()
 
 void Visualizer::VisThread()
 {
-    while (1)
+    while (appRunning==true)
     {
         if (!(netmode == NET_MODE_CLIENT && port->connected))
         {

--- a/KeyboardVisualizerCommon/Visualizer.cpp
+++ b/KeyboardVisualizerCommon/Visualizer.cpp
@@ -987,6 +987,18 @@ void Visualizer::StartThread()
 #endif
 }
 
+void Visualizer::DrawRGBOut()
+{
+	COLORREF color = 0x00000000;
+	for (int x = 0; x < 256; x++)
+	{
+		for (int y = 0; y < 64; y++)
+		{
+			pixels_render->pixels[y][x] = RGB((GetRValue(color) / 256), (GetGValue(color) / 256), (GetBValue(color) / 256));
+		}
+	}
+}
+
 void DrawSolidColor(int bright, COLORREF color, vis_pixels *pixels)
 {
     bright = (int)(bright * (255.0f / 100.0f));

--- a/KeyboardVisualizerCommon/Visualizer.h
+++ b/KeyboardVisualizerCommon/Visualizer.h
@@ -151,6 +151,9 @@ public:
     //Flag to update UI
     bool update_ui;
 
+	//Flag if program is running
+	bool appRunning;
+
     //Visualizer Background
     vis_pixels pixels_bg;
 

--- a/KeyboardVisualizerCommon/Visualizer.h
+++ b/KeyboardVisualizerCommon/Visualizer.h
@@ -119,6 +119,9 @@ public:
     //Draw Pattern
     void DrawPattern(VISUALIZER_PATTERN pattern, int bright, vis_pixels *pixels);
 
+	//Draw LED Out
+	void DrawRGBOut();
+
     //Add LED strip
     void AddLEDStrip(char* ledstring);
     void AddLEDStripXmas(char * ledstring);

--- a/KeyboardVisualizerVC/KeyboardVisDlg.cpp
+++ b/KeyboardVisualizerVC/KeyboardVisDlg.cpp
@@ -135,6 +135,8 @@ void KeyboardVisDlg::StartMinimized(boolean startmin)
 
 void KeyboardVisDlg::OnDestroy()
 {
+	vis->DrawRGBOut();
+
     NOTIFYICONDATA Tray;
 
     Tray.cbSize = sizeof(Tray);
@@ -144,8 +146,7 @@ void KeyboardVisDlg::OnDestroy()
     Tray.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE;
     Tray.uID = ID_SYSTEMTRAY;
     Tray.uCallbackMessage = WM_TRAYICON_EVENT;
-	vis->DrawRGBOut();
-
+	
     Shell_NotifyIcon(NIM_DELETE, &Tray);
 }
 

--- a/KeyboardVisualizerVC/KeyboardVisDlg.cpp
+++ b/KeyboardVisualizerVC/KeyboardVisDlg.cpp
@@ -144,6 +144,7 @@ void KeyboardVisDlg::OnDestroy()
     Tray.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE;
     Tray.uID = ID_SYSTEMTRAY;
     Tray.uCallbackMessage = WM_TRAYICON_EVENT;
+	vis->DrawRGBOut();
 
     Shell_NotifyIcon(NIM_DELETE, &Tray);
 }

--- a/KeyboardVisualizerVC/KeyboardVisualizerVC.vcxproj
+++ b/KeyboardVisualizerVC/KeyboardVisualizerVC.vcxproj
@@ -182,6 +182,7 @@
     <ClCompile Include="..\KeyboardVisualizerCommon\LogitechSDK.cpp" />
     <ClCompile Include="..\KeyboardVisualizerCommon\MSIKeyboard.cpp" />
     <ClCompile Include="..\KeyboardVisualizerCommon\net_port.cpp" />
+    <ClCompile Include="..\KeyboardVisualizerCommon\PoseidonZRGBKeyboard.cpp" />
     <ClCompile Include="..\KeyboardVisualizerCommon\RazerChroma.cpp" />
     <ClCompile Include="..\KeyboardVisualizerCommon\serial_port.cpp" />
     <ClCompile Include="..\KeyboardVisualizerCommon\SteelSeriesGameSense.cpp" />
@@ -199,6 +200,7 @@
     <ClInclude Include="..\KeyboardVisualizerCommon\LogitechSDK.h" />
     <ClInclude Include="..\KeyboardVisualizerCommon\MSIKeyboard.h" />
     <ClInclude Include="..\KeyboardVisualizerCommon\net_port.h" />
+    <ClInclude Include="..\KeyboardVisualizerCommon\PoseidonZRGBKeyboard.h" />
     <ClInclude Include="..\KeyboardVisualizerCommon\RazerChroma.h" />
     <ClInclude Include="..\KeyboardVisualizerCommon\serial_port.h" />
     <ClInclude Include="..\KeyboardVisualizerCommon\SteelSeriesGameSense.h" />


### PR DESCRIPTION
When the OnDestroy Event is triggered a function DrawRGBOut is called which kills the main thread and slowly fades out the current colors (to customize simply change the numbers (currently 0.8 behind the GetRValue/GetGValue/GetBValue)). #90 