### PR TITLE
Channel Selection, Bugfix

### DIFF
--- a/KeyboardVisualizerCommon/LEDStrip.cpp
+++ b/KeyboardVisualizerCommon/LEDStrip.cpp
@@ -91,8 +91,8 @@ void LEDStrip::InitializeHuePlus(char* ledstring)
 
 	LPSTR   source = NULL;
 	LPSTR channels = NULL;
-	LPSTR   numleds = NULL;
-	LPSTR   next = NULL;
+	LPSTR  numleds = NULL;
+	LPSTR     next = NULL;
 
 	source = strtok_s(ledstring, ",", &next);
 
@@ -292,8 +292,8 @@ void LEDStrip::SetLEDsHuePlus(COLORREF pixels[64][256])
     if (serialport != NULL)
     {
         unsigned char *serial_buf;
-
-        serial_buf = new unsigned char[125];    //Size of Message always 5 XX Blocks (Mode Selection) +  3 XX for each LED (1 color) 
+		const int hueSize = 125;
+        serial_buf = new unsigned char[hueSize];    //Size of Message always 5 XX Blocks (Mode Selection) +  3 XX for each LED (1 color) 
                                                 //-> max of 40 LEDs per Channel (or 5 Fans a 8 LEDs) -> 125 Blocks (empty LEDs are written, too)
 
         serial_buf[0] = 0x4b;
@@ -302,7 +302,7 @@ void LEDStrip::SetLEDsHuePlus(COLORREF pixels[64][256])
         serial_buf[3] = fans; 
         serial_buf[4] = 0x00;
 
-        for (int i = 5; i < 125; i++)
+        for (int i = 5; i < hueSize; i++)
         {
             //clearing the buf otherwise sometimes strange things are written to the COM Port
             serial_buf[i] = 0x00;
@@ -317,7 +317,7 @@ void LEDStrip::SetLEDsHuePlus(COLORREF pixels[64][256])
             serial_buf[idx + 7] = GetBValue(color);
         }
 
-        serialport->serial_write((char *)serial_buf,125);
+        serialport->serial_write((char *)serial_buf,hueSize);
         serialport->serial_flush_tx();
 
         delete[] serial_buf;

--- a/KeyboardVisualizerCommon/LEDStrip.cpp
+++ b/KeyboardVisualizerCommon/LEDStrip.cpp
@@ -292,7 +292,7 @@ void LEDStrip::SetLEDsHuePlus(COLORREF pixels[64][256])
     if (serialport != NULL)
     {
         unsigned char *serial_buf;
-		const int hueSize = 125;
+		
         serial_buf = new unsigned char[hueSize];    //Size of Message always 5 XX Blocks (Mode Selection) +  3 XX for each LED (1 color) 
                                                 //-> max of 40 LEDs per Channel (or 5 Fans a 8 LEDs) -> 125 Blocks (empty LEDs are written, too)
 

--- a/KeyboardVisualizerCommon/LEDStrip.h
+++ b/KeyboardVisualizerCommon/LEDStrip.h
@@ -38,6 +38,7 @@ private:
     int num_leds;
     int fans;
 	int channel;
+	const int hueSize = 125;
 
     int * LEDStripXIndex;
     int * LEDStripYIndex;

--- a/KeyboardVisualizerCommon/LEDStrip.h
+++ b/KeyboardVisualizerCommon/LEDStrip.h
@@ -37,6 +37,7 @@ private:
     int baud_rate;
     int num_leds;
     int fans;
+	int channel;
 
     int * LEDStripXIndex;
     int * LEDStripYIndex;

--- a/KeyboardVisualizerVC/KeyboardVisualizerVC.vcxproj
+++ b/KeyboardVisualizerVC/KeyboardVisualizerVC.vcxproj
@@ -182,6 +182,7 @@
     <ClCompile Include="..\KeyboardVisualizerCommon\LogitechSDK.cpp" />
     <ClCompile Include="..\KeyboardVisualizerCommon\MSIKeyboard.cpp" />
     <ClCompile Include="..\KeyboardVisualizerCommon\net_port.cpp" />
+    <ClCompile Include="..\KeyboardVisualizerCommon\PoseidonZRGBKeyboard.cpp" />
     <ClCompile Include="..\KeyboardVisualizerCommon\RazerChroma.cpp" />
     <ClCompile Include="..\KeyboardVisualizerCommon\serial_port.cpp" />
     <ClCompile Include="..\KeyboardVisualizerCommon\SteelSeriesGameSense.cpp" />
@@ -199,6 +200,7 @@
     <ClInclude Include="..\KeyboardVisualizerCommon\LogitechSDK.h" />
     <ClInclude Include="..\KeyboardVisualizerCommon\MSIKeyboard.h" />
     <ClInclude Include="..\KeyboardVisualizerCommon\net_port.h" />
+    <ClInclude Include="..\KeyboardVisualizerCommon\PoseidonZRGBKeyboard.h" />
     <ClInclude Include="..\KeyboardVisualizerCommon\RazerChroma.h" />
     <ClInclude Include="..\KeyboardVisualizerCommon\serial_port.h" />
     <ClInclude Include="..\KeyboardVisualizerCommon\SteelSeriesGameSense.h" />

--- a/KeyboardVisualizerVC/main.cpp
+++ b/KeyboardVisualizerVC/main.cpp
@@ -281,7 +281,7 @@ boolean parse_command_line(char * command_line)
             printf("                      - (ex.ledstrip=udp:192.168.1.5,1234,30)\r\n");
             printf("    xmas              - COM port, ex. xmas=COM2\r\n");
             printf("	hueplus			  - HUE+ config:\r\n");
-            printf("					  - hueplus=port,channel,num_leds\r\n");
+			printf("					  - hueplus=port,channel,num_leds\r\n");
 			printf("					  - channel: 0 -> both channels, 1 -> channel 1, 2 -> channel 2\r\n");
             printf("					  - num_leds: Fans * 8 ex. 3 Fans -> 24\r\n");
             printf("					  - Important for Fans: If you have connected fans on both channels only count the fans on the channel with the most fans\r\n");

--- a/KeyboardVisualizerVC/main.cpp
+++ b/KeyboardVisualizerVC/main.cpp
@@ -281,12 +281,13 @@ boolean parse_command_line(char * command_line)
             printf("                      - (ex.ledstrip=udp:192.168.1.5,1234,30)\r\n");
             printf("    xmas              - COM port, ex. xmas=COM2\r\n");
             printf("	hueplus			  - HUE+ config:\r\n");
-            printf("					  - hueplus=port,num_leds\r\n");
+            printf("					  - hueplus=port,channel,num_leds\r\n");
+			printf("					  - channel: 0 -> both channels, 1 -> channel 1, 2 -> channel 2\r\n");
             printf("					  - num_leds: Fans * 8 ex. 3 Fans -> 24\r\n");
             printf("					  - Important for Fans: If you have connected fans on both channels only count the fans on the channel with the most fans\r\n");
             printf("											ex. 3 Fans on Ch. 1 4 Fans on CH. 2: num_leds 32 for the 4 Fans\r\n");
             printf("											For best Visualizer results don`t connect on one channel 3 fans more than on the other channel\r\n");
-            printf("					  - (ex. hueplus=COM4,24\r\n");
+            printf("					  - (ex. hueplus=COM4,1,24\r\n");
             return FALSE;
         }
 


### PR DESCRIPTION
channels are now selecteable. Bugfix, which caused flickering when in singe color mode, Bugfix which caused slow fading between colors.

Syntax:
hueplus=COM-Port,channel,leds
ex.: hueplus=COM4,0,8

channel: 
0 -> both channels
1 -> channel 1
2-> channel 2
when 1/2 selected: the other channel will display the last color/stays out/gets no updates

leds:
fans * 8, always the number of one channel (the one with more fans)

For LED-Strip support: I dont know exactly if it is working as I dont own these. I can implement it if somebody sends me a dump session with a serial monitor (eg.: http://www.eltima.com/products/serial-port-monitor/ (free trial)). Just send in CAM some static colors and document which and how many LEDs you have connected. If you can vary colors and number of LEDs and send me the different dumps it would be easier, but one would be better then nothing :)
