### PR TITLE
added color average filtering to razer chroma keyboard code

### DIFF
--- a/KeyboardVisualizerCommon/RazerChroma.h
+++ b/KeyboardVisualizerCommon/RazerChroma.h
@@ -44,6 +44,7 @@ public:
     bool use_keyboard_generic_effect;
     bool use_headset_custom_effect;
     bool use_chromalink_single_color;
+    bool use_keyboard_nearest_filter;
     int chroma_box_mode;
     bool disable_chromalink;
 

--- a/KeyboardVisualizerCommon/Visualizer.cpp
+++ b/KeyboardVisualizerCommon/Visualizer.cpp
@@ -333,6 +333,10 @@ void Visualizer::SetDeviceProperty(char * devprop, char * argument)
     {
         rkb.use_chromalink_single_color = true;
     }
+    else if (strcmp(devprop, "razer_use_keyboard_nearest_filter") == 0)
+    {
+        rkb.use_keyboard_nearest_filter = true;
+    }
     else if (strcmp(devprop, "razer_disable_chromalink") == 0)
     {
         rkb.disable_chromalink = true;


### PR DESCRIPTION
I personally didnt really like how the keys just took the nearest pixel to display because it would often lead to the keys flickering "on" and "off", never fading in/out so I wrote up a bit of code to blend all the pixels surrounding a key together, smoothing out the look, especially when the background mode is set to black.