### PR TITLE
Fixed OpenAL usage to release (delete) stale capture devies/streams

### DIFF
--- a/KeyboardVisualizerCommon/Visualizer.cpp
+++ b/KeyboardVisualizerCommon/Visualizer.cpp
@@ -211,6 +211,7 @@ void Visualizer::ChangeAudioDevice()
     if(device != NULL)
     {
         alcCaptureStop(device);
+        alcCaptureCloseDevice(device);
     }
 
     if(audio_device_idx < audio_devices.size())


### PR DESCRIPTION
The app haven't been releasing the devices properly, only stopping the recording. This led to a bunch of stale streams hanging in the system. This PR addresses that issue.